### PR TITLE
fix for sheets in subfolders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: objective-c  # Do tests on OS X
+language: python
 env:
   global:
     - SKIP_IMAGE_CHECK=1
@@ -9,14 +9,5 @@ env:
     - TOXENV=sphinx11
     - TOXENV=sphinx12
     - TOXENV=coverage
-cache:
-  directories:
-    - /Library/Caches/Homebrew
-    - /opt/homebrew-cask/Caskroom/
-before_install:
-  - brew tap caskroom/cask
-  - brew install brew-cask python python3
-  - brew cask update
-  - brew cask install astah-community
 install: pip install docutils tox
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -103,4 +103,4 @@ Configuration Options
 
 astah_command_path
 
-  path to astah-command.sh (or astah-command.bat)
+  path to astah-command.sh (or astah-command.bat). This can be a simple string or a dictionary of paths based on file extensions.

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ from setuptools import setup, find_packages
 
 long_desc = open('README.rst').read()
 
-requires = ['Sphinx>=0.6', 'sphinxcontrib-imagehelper']
+requires = ['Sphinx>=3.0', 'sphinxcontrib-imagehelper>=1.1.2']
 
 setup(
     name='sphinxcontrib-astah',
-    version='1.0.0',
+    version='1.0.1',
     url='https://github.com/tk0miya/sphinxcontrib-astah',
     license='BSD',
     author='Takeshi KOMIYA',
@@ -25,10 +25,10 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Documentation',
         'Topic :: Documentation :: Sphinx',
         'Topic :: Utilities',

--- a/sphinxcontrib/astah.py
+++ b/sphinxcontrib/astah.py
@@ -7,10 +7,12 @@ from tempfile import mkdtemp
 from shutil import copyfile, rmtree
 from docutils.parsers.rst import directives
 from sphinx.util.osutil import ensuredir
+from sphinx.util import logging
 from sphinxcontrib.imagehelper import (
     ImageConverter, add_image_type, generate_image_directive, generate_figure_directive
 )
 
+logger = logging.getLogger(__name__)
 
 class AstahException(Exception):
     pass
@@ -19,7 +21,6 @@ class AstahException(Exception):
 class Astah(object):
     def __init__(self, app):
         self.astah_command_path = app.config.astah_command_path
-        self.warn = app.warn
 
     @property
     def command_path(self):
@@ -36,13 +37,13 @@ class Astah(object):
 
     def extract(self, filename, dir):
         if self.command_path is None:
-            self.warn('astah-command.sh (or .bat) not found. set astah_command_path in your conf.py')
+            logger.warning('astah-command.sh (or .bat) not found. set astah_command_path in your conf.py')
             raise AstahException
 
         command_args = [self.command_path, '-image', 'all', '-f', filename, '-o', dir]
         retcode = subprocess.call(command_args)
         if retcode != 0:
-            self.warn('Fail to convert astah image (exitcode: %s)' % retcode)
+            logger.warning('Fail to convert astah image (exitcode: %s)' % retcode)
             raise AstahException
 
     def convert(self, filename, to, sheetname=None):
@@ -65,12 +66,12 @@ class Astah(object):
                 copyfile(target, to)
                 return True
             else:
-                self.warn('Fail to convert astah image: unknown sheet [%s]' % sheetname)
+                logger.warning('Fail to convert astah image: unknown sheet [%s]' % sheetname)
                 return False
         except AstahException:
             return False
         except Exception as exc:
-            self.warn('Fail to convert astah image: %s' % exc)
+            logger.warning('Fail to convert astah image: %s' % exc)
             return False
         finally:
             rmtree(tmpdir, ignore_errors=True)

--- a/sphinxcontrib/astah.py
+++ b/sphinxcontrib/astah.py
@@ -53,7 +53,10 @@ class Astah(object):
             subdirname = os.path.splitext(os.path.basename(filename))[0]
             imagedir = os.path.join(tmpdir, subdirname)
             if sheetname:
-                target = os.path.join(imagedir, sheetname + '.png')
+                for root, dirs, files in os.walk(imagedir):
+                    if sheetname + '.png' in files:
+                        target = os.path.join(root, sheetname + '.png')
+
             else:
                 target = os.path.join(imagedir, os.listdir(imagedir)[0])  # first item in archive
 
@@ -62,7 +65,7 @@ class Astah(object):
                 copyfile(target, to)
                 return True
             else:
-                self.warn('Fail to convert astah image: unknown sheet [%s]' % self['sheet'])
+                self.warn('Fail to convert astah image: unknown sheet [%s]' % sheetname)
                 return False
         except AstahException:
             return False

--- a/sphinxcontrib/astah.py
+++ b/sphinxcontrib/astah.py
@@ -22,10 +22,14 @@ class Astah(object):
     def __init__(self, app):
         self.astah_command_path = app.config.astah_command_path
 
-    @property
-    def command_path(self):
-        if self.astah_command_path:
+    def get_command_path(self, filename):
+        if isinstance(self.astah_command_path, str):
             return self.astah_command_path
+
+        if isinstance(self.astah_command_path, dict):
+           for ext, path in self.astah_command_path.items():
+               if filename.find('.' + ext) > 0:
+                   return path
 
         patterns = ['/Applications/astah*/astah-command.sh']  # Mac OS X
         for pattern in patterns:
@@ -36,11 +40,12 @@ class Astah(object):
         return None
 
     def extract(self, filename, dir):
-        if self.command_path is None:
+        command_path = self.get_command_path(filename)
+        if command_path is None:
             logger.warning('astah-command.sh (or .bat) not found. set astah_command_path in your conf.py')
             raise AstahException
 
-        command_args = [self.command_path, '-image', 'all', '-f', filename, '-o', dir]
+        command_args = [command_path, '-image', 'all', '-f', filename, '-o', dir]
         retcode = subprocess.call(command_args)
         if retcode != 0:
             logger.warning('Fail to convert astah image (exitcode: %s)' % retcode)


### PR DESCRIPTION
This is a quick fix that works for me. I guess up until now, the plugin has only been tested on model files with everything at the top level. Exporting images in subfolders creates a folder hierarchy to match. 